### PR TITLE
Fix using incorrect port number for stream if not specified

### DIFF
--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -826,9 +826,10 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
 
       connectionFlow = {
         val host = baseUri_.authority.host.toString()
+        val port = baseUri_.effectivePort
         if (request.uri.scheme.equalsIgnoreCase("https"))
-          http.outgoingConnectionHttps(host)
-        else http.outgoingConnection(host)
+          http.outgoingConnectionHttps(host, port)
+        else http.outgoingConnection(host, port)
       }
       response <- Source
                    .single(request)
@@ -986,7 +987,7 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
 
       connectionFlow = {
         val host = baseUri_.authority.host.toString()
-        val port = baseUri_.authority.port
+        val port = baseUri_.effectivePort
         if (request.uri.scheme.equalsIgnoreCase("https"))
           http.outgoingConnectionHttps(host = host, port = port, settings = clientConnectionSettings)
         else http.outgoingConnection(host = host, port = port, settings = clientConnectionSettings)
@@ -1073,9 +1074,9 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
                             ()
                           },
                         streamConfig: Subscriptions.StreamConfig = Subscriptions.StreamConfig(),
-                        modifySourceFunction: Option[(Source[SubscriptionEvent[T], UniqueKillSwitch]) => (
-                          Source[SubscriptionEvent[T],
-                                 UniqueKillSwitch])] = None)(
+                        modifySourceFunction: Option[
+                          Source[SubscriptionEvent[T], UniqueKillSwitch] => Source[SubscriptionEvent[T],
+                                                                                   UniqueKillSwitch]] = None)(
       implicit decoder: Decoder[List[Event[T]]],
       flowId: FlowId = randomFlowId(),
       executionContext: ExecutionContext,
@@ -1252,9 +1253,9 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
                                    ()
                                  },
                                streamConfig: Subscriptions.StreamConfig = Subscriptions.StreamConfig(),
-                               modifySourceFunction: Option[(Source[SubscriptionEvent[T], UniqueKillSwitch]) => (
-                                 Source[SubscriptionEvent[T],
-                                        UniqueKillSwitch])] = None)(
+                               modifySourceFunction: Option[
+                                 Source[SubscriptionEvent[T], UniqueKillSwitch] => Source[SubscriptionEvent[T],
+                                                                                          UniqueKillSwitch]] = None)(
       implicit decoder: Decoder[List[Event[T]]],
       flowId: FlowId = randomFlowId(),
       executionContext: ExecutionContext,

--- a/src/test/scala/BasicSpec.scala
+++ b/src/test/scala/BasicSpec.scala
@@ -11,7 +11,11 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.specification.core.SpecStructure
 import org.zalando.kanadi.Config
-import org.zalando.kanadi.api.Subscriptions.{ConnectionClosedCallback, EventCallback, defaultEventStreamSupervisionDecider}
+import org.zalando.kanadi.api.Subscriptions.{
+  ConnectionClosedCallback,
+  EventCallback,
+  defaultEventStreamSupervisionDecider
+}
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models._
 


### PR DESCRIPTION
Turns out that this commit https://github.com/zalando-incubator/kanadi/pull/4/commits/ef388f76fc6e515803236b9fd28221a402ed1476 caused a regression. If a port is not stated (i.e. you only specify a host), it will use `0` as a port number causing Kanadi to fail to connect on a stream.

There is an `effectivePort` method which gives you the proper port that you are meant to use. So if there is no port specified (i.e. what resulted in `0`), it will default to `80` for http and `443` for https.

I verified that this works locally by connecting to Zalando's Nakadi server and making sure the tests pass.

This PR also does some minor syntactic cleanup