### PR TITLE
Make typesafe config configurable + lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ import io.circe.syntax._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
 import org.zalando.kanadi.api.Subscription
 import org.zalando.kanadi.api.Subscriptions
 import org.zalando.kanadi.models.EventTypeName
@@ -331,12 +332,13 @@ object SomeEvent {
   )(SomeEvent.apply)
 }
 
-object Main extends App {
+object Main extends App with Config {
+  val config = ConfigFactory.load()
   implicit val system = ActorSystem()
   implicit val http = Http()
   implicit val materializer = ActorMaterializer()
   
-  val subscriptionsClient = Subscriptions(Config.nakadiUri)
+  val subscriptionsClient = Subscriptions(nakadiUri)
   
   def createOrGetSubscription = subscriptionsClient.createIfDoesntExist(
     Subscription(
@@ -360,6 +362,7 @@ import io.circe.syntax._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
 import org.zalando.kanadi.api.Subscription
 import org.zalando.kanadi.api.Subscriptions
 import org.zalando.kanadi.api.Subscriptions._
@@ -382,12 +385,13 @@ object SomeEvent {
   )(SomeEvent.apply)
 }
 
-object Main extends App {
+object Main extends App with Config {
+  val config = ConfigFactory.load()
   implicit val system = ActorSystem()
   implicit val http = Http()
   implicit val materializer = ActorMaterializer()
   
-  val subscriptionsClient = Subscriptions(Config.nakadiUri)
+  val subscriptionsClient = Subscriptions(nakadiUri)
 
   def createOrGetSubscription = subscriptionsClient.createIfDoesntExist(
     Subscription(
@@ -432,6 +436,7 @@ import io.circe.syntax._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
 import org.zalando.kanadi.api.Subscription
 import org.zalando.kanadi.api.Subscriptions
 import org.zalando.kanadi.api.Subscriptions._
@@ -455,12 +460,13 @@ object SomeEvent {
   )(SomeEvent.apply)
 }
 
-object Main extends App {
+object Main extends App with Config {
+  val config = ConfigFactory.load()
   implicit val system = ActorSystem()
   implicit val http = Http()
   implicit val materializer = ActorMaterializer()
   
-  val subscriptionsClient = Subscriptions(Config.nakadiUri)
+  val subscriptionsClient = Subscriptions(nakadiUri)
 
   def createOrGetSubscription = subscriptionsClient.createIfDoesntExist(
     Subscription(
@@ -509,6 +515,7 @@ import io.circe.syntax._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.{ActorMaterializer, ThrottleMode}
+import com.typesafe.config.ConfigFactory
 import org.zalando.kanadi.api.Subscription
 import org.zalando.kanadi.api.Subscriptions
 import org.zalando.kanadi.api.Subscriptions._
@@ -533,12 +540,13 @@ object SomeEvent {
   )(SomeEvent.apply)
 }
 
-object Main extends App {
+object Main extends App with Config {
+  val config = ConfigFactory.load()
   implicit val system = ActorSystem()
   implicit val http = Http()
   implicit val materializer = ActorMaterializer()
   
-  val subscriptionsClient = Subscriptions(Config.nakadiUri)
+  val subscriptionsClient = Subscriptions(nakadiUri)
 
   def createOrGetSubscription = subscriptionsClient.createIfDoesntExist(
     Subscription(
@@ -616,6 +624,7 @@ You can also provide an alternate supervision decider (make sure that you don't 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.FlowId
 import org.zalando.kanadi.models.{SubscriptionId, StreamId}
 import org.zalando.kanadi.api.{Subscriptions, SubscriptionCursor}
@@ -624,12 +633,12 @@ import akka.stream.Supervision
 import org.zalando.kanadi.Config
 
 object Main extends App with Config {
-
+  val config = ConfigFactory.load()
   implicit val system = ActorSystem()
   implicit val http = Http()
   implicit val materializer = ActorMaterializer()
   
-  val subscriptionsClient = Subscriptions(Config.nakadiUri)
+  val subscriptionsClient = Subscriptions(nakadiUri)
 
   import org.mdedetrich.webmodels.FlowId
   import org.zalando.kanadi.models.{SubscriptionId, StreamId}
@@ -668,6 +677,7 @@ import io.circe.syntax._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.FlowId
 import org.zalando.kanadi.models.{SubscriptionId, StreamId}
 import org.zalando.kanadi.api.{Subscriptions, SubscriptionCursor}
@@ -694,12 +704,12 @@ object SomeEvent {
 }
 
 object Main extends App with Config {
-
+  val config = ConfigFactory.load()
   implicit val system = ActorSystem()
   implicit val http = Http()
   implicit val materializer = ActorMaterializer()
   
-  val subscriptionsClient = Subscriptions(Config.nakadiUri)
+  val subscriptionsClient = Subscriptions(nakadiUri)
 
   import org.mdedetrich.webmodels.FlowId
   import org.zalando.kanadi.models.{SubscriptionId, StreamId}
@@ -769,18 +779,23 @@ requests).
 For OAuth2 implicit flow authentication, you need to provide a function that defines how you retrieve the token, i.e.
 
 ```scala
+import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.{OAuth2Token, OAuth2TokenProvider}
 import org.zalando.kanadi.api.Subscriptions
 import org.zalando.kanadi.models._
 import org.zalando.kanadi.Config
 import scala.concurrent.Future  
 
-val oAuth2TokenProvider = Option(
-  OAuth2TokenProvider(
-    () => Future.successful(OAuth2Token(sys.props("TOKEN"))))
-)
-
-val subscriptionsClient = Subscriptions(Config.nakadiUri, oAuth2TokenProvider)
+object Main extends App with Config {
+  val config = ConfigFactory.load()
+  
+  val oAuth2TokenProvider = Option(
+    OAuth2TokenProvider(
+      () => Future.successful(OAuth2Token(sys.props("TOKEN"))))
+  )
+    
+  val subscriptionsClient = Subscriptions(nakadiUri, oAuth2TokenProvider)
+}
 ```
 
 Note that Kanadi will automatically censor the tokenId (this is done by overriding the `.toString` method for the

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -5,8 +5,8 @@ kanadi {
   }
 
   http-config {
-    censor-oAuth2-token = true
-    censor-oAuth2-token = ${?KANADI_HTTP_CONFIG_CENSOR_OAUTH2_TOKEN}
+    censor-o-auth-2-token = true
+    censor-o-auth-2-token = ${?KANADI_HTTP_CONFIG_CENSOR_OAUTH2_TOKEN}
     single-string-chunk-length = 8
     single-string-chunk-length = ${?KANADI_HTTP_CONFIG_SINGLE_STRING_CHUNK_LENGTH}
     event-list-chunk-length = 300

--- a/src/main/scala/org/zalando/kanadi/Config.scala
+++ b/src/main/scala/org/zalando/kanadi/Config.scala
@@ -2,25 +2,15 @@ package org.zalando.kanadi
 
 import java.net.URI
 
-import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
 import org.zalando.kanadi.models.HttpConfig
-
-import scala.concurrent.duration.FiniteDuration
+import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
 
 trait Config {
-  private val conf = ConfigFactory.load
+  def config: com.typesafe.config.Config
 
-  implicit val nakadiUri = new URI(conf.as[String]("kanadi.nakadi.uri"))
+  implicit lazy val nakadiUri: URI = new URI(config.as[String]("kanadi.nakadi.uri"))
 
-  implicit val kanadiHttpConfig = HttpConfig(
-    conf.as[Boolean]("kanadi.http-config.censor-oAuth2-token"),
-    conf.as[Int]("kanadi.http-config.single-string-chunk-length"),
-    conf.as[Int]("kanadi.http-config.event-list-chunk-length"),
-    conf.as[FiniteDuration]("kanadi.http-config.no-empty-slots-cursor-reset-retry-delay"),
-    conf.as[FiniteDuration]("kanadi.http-config.server-disconnect-retry-delay")
-  )
-
+  implicit lazy val kanadiHttpConfig: HttpConfig = config.as[HttpConfig]("kanadi.http-config")
 }
-
-object Config extends Config

--- a/src/test/scala/BadJsonDecodingSpec.scala
+++ b/src/test/scala/BadJsonDecodingSpec.scala
@@ -3,6 +3,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.{ActorMaterializer, Supervision}
+import com.typesafe.config.ConfigFactory
 import io.circe.{Decoder, Encoder}
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
@@ -47,6 +48,8 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
     Delete subscription        $deleteSubscription
     Delete event type          $deleteEventType
     """
+
+  val config = ConfigFactory.load()
 
   implicit val system       = ActorSystem()
   implicit val http         = Http()

--- a/src/test/scala/BasicSourceSpec.scala
+++ b/src/test/scala/BasicSourceSpec.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Sink}
+import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
@@ -29,6 +30,8 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
     Delete subscription        $deleteSubscription
     Delete event type          $deleteEventType
     """
+
+  val config = ConfigFactory.load()
 
   implicit val system       = ActorSystem()
   implicit val http         = Http()

--- a/src/test/scala/BasicSpec.scala
+++ b/src/test/scala/BasicSpec.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
 import io.circe.{Decoder, Encoder}
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
@@ -35,6 +36,8 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
     Delete subscription        $deleteSubscription
     Delete event type          $deleteEventType
     """
+
+  val config = ConfigFactory.load()
 
   implicit val system       = ActorSystem()
   implicit val http         = Http()

--- a/src/test/scala/OAuthFailedSpec.scala
+++ b/src/test/scala/OAuthFailedSpec.scala
@@ -1,6 +1,7 @@
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
 import io.circe.Json
 import org.mdedetrich.webmodels.{FlowId, OAuth2Token, OAuth2TokenProvider}
 import org.specs2.Specification
@@ -15,6 +16,8 @@ import concurrent.duration._
 import scala.concurrent.Future
 
 class OAuthFailedSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
+
+  val config = ConfigFactory.load()
 
   implicit val system       = ActorSystem()
   implicit val http         = Http()

--- a/src/test/scala/SubscriptionsSpec.scala
+++ b/src/test/scala/SubscriptionsSpec.scala
@@ -3,6 +3,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
@@ -21,9 +22,12 @@ class SubscriptionsSpec(implicit ec: ExecutionEnv) extends Specification with Co
       Create enough subscriptions to ensure that pagination is used $createEnoughSubscriptionsToUsePagination
     """
 
+  val config = ConfigFactory.load()
+
   implicit val system       = ActorSystem()
   implicit val http         = Http()
   implicit val materializer = ActorMaterializer()
+
   val eventTypeName         = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
   val OwningApplication     = "KANADI"
   val consumerGroup: String = UUID.randomUUID().toString


### PR DESCRIPTION
This PR does 2 things

- Make the configuration `lazy`. We were having issues due to initialization from our side so the configs are set as a lazy val
- The typesafe `config` is now a def that needs to be supplied.
- Simplifies the configuration