### PR TITLE
Add EventType/SubscriptionType Authorization fields #29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  - wget https://raw.githubusercontent.com/adyach/nakadi-docker/master/docker-compose.yml
 
 before_script:
   - sudo service mysql stop # By default travis has a MySQL service running, turn it off to prevent conflicts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '2'
+services:
+  nakadi:
+    image: adyach/nakadi-docker:latest
+    ports:
+     - "8080:8080"
+    depends_on:
+     - postgres
+     - zookeeper
+     - kafka
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - NAKADI_OAUTH2_MODE=OFF
+      - NAKADI_ZOOKEEPER_BROKERS=zookeeper:2181
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/local_nakadi_db
+      - NAKADI_PLUGINS_AUTHZ_FACTORY=org.crazycoder.nakadiauthzfileplugin.FileAuthorizationServiceFactory
+
+  postgres:
+    image: adyach/nakadi-postgres:latest
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: nakadi
+      POSTGRES_PASSWORD: nakadi
+      POSTGRES_DB: local_nakadi_db
+
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka:0.10.1.0
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
+      KAFKA_BROKER_ID: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+

--- a/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
@@ -144,6 +144,42 @@ object EventTypeStatistics {
     )(EventTypeStatistics.apply)
 }
 
+case class AuthorizationAttribute(dataType: String, value: String)
+
+object AuthorizationAttribute {
+  implicit val eventTypeAuthorizationAuthorizationAttributeEncoder: Encoder[AuthorizationAttribute] =
+    Encoder.forProduct2(
+      "data_type",
+      "value"
+    )(x => AuthorizationAttribute.unapply(x).get)
+
+  implicit val eventTypeAuthorizationAuthorizationAttributeDecoder: Decoder[AuthorizationAttribute] =
+    Decoder.forProduct2(
+      "data_type",
+      "value"
+    )(AuthorizationAttribute.apply)
+}
+
+case class EventTypeAuthorization(admins: List[AuthorizationAttribute],
+                                  readers: List[AuthorizationAttribute],
+                                  writers: List[AuthorizationAttribute])
+
+object EventTypeAuthorization {
+  implicit val eventTypeAuthorizationEncoder: Encoder[EventTypeAuthorization] =
+    Encoder.forProduct3(
+      "admins",
+      "readers",
+      "writers"
+    )(x => EventTypeAuthorization.unapply(x).get)
+
+  implicit val eventTypeAuthorizationDecoder: Decoder[EventTypeAuthorization] =
+    Decoder.forProduct3(
+      "admins",
+      "readers",
+      "writers"
+    )(EventTypeAuthorization.apply)
+}
+
 case class EventTypeOptions(retentionTime: Int)
 
 object EventTypeOptions {
@@ -170,6 +206,7 @@ object EventTypeOptions {
   * @param partitionKeyFields Required when [[partitionStrategy]] is set to [[org.zalando.kanadi.api.PartitionStrategy.Hash]]. Must be absent otherwise. Indicates the fields used for evaluation the partition of Events of this type. If set it MUST be a valid required field as defined in the schema.
   * @param defaultStatistic Operational statistics for an [[EventType]]. This data MUST be provided by users on Event Type creation. Nakadi uses this object in order to provide an optimal number of partitions from a throughput perspective.
   * @param options Additional parameters for tuning internal behavior of Nakadi.
+  * @param authorization Authorization section for an event type. This section defines three access control lists: one for producing events [[EventTypeAuthorization.writers]], one for consuming events [[EventTypeAuthorization.readers]], and one for administering an event type [[EventTypeAuthorization.admins]]. Regardless of the values of the authorization properties, administrator accounts will always be authorized.
   * @param writeScopes This field is used for event publishing access control. Nakadi only authorises publishers whose session contains at least one of the scopes in this list. If no scopes provided then anyone can publish to this event type.
   * @param readScopes This field is used for event consuming access control. Nakadi only authorises consumers whose session contains at least one of the scopes in this list. If no scopes provided then anyone can consume from this event type.
   * @param createdAt Date and time when this event type was created.
@@ -186,6 +223,7 @@ case class EventType(
     partitionKeyFields: Option[List[String]] = None,
     defaultStatistic: Option[EventTypeStatistics] = None,
     options: Option[EventTypeOptions] = None,
+    authorization: Option[EventTypeAuthorization] = None,
     writeScopes: Option[List[WriteScope]] = None,
     readScopes: Option[List[ReadScope]] = None,
     createdAt: Option[OffsetDateTime] = None,
@@ -193,7 +231,7 @@ case class EventType(
 )
 
 object EventType {
-  implicit val eventTypeEncoder: Encoder[EventType] = Encoder.forProduct14(
+  implicit val eventTypeEncoder: Encoder[EventType] = Encoder.forProduct15(
     "name",
     "owning_application",
     "category",
@@ -204,13 +242,14 @@ object EventType {
     "partition_key_fields",
     "default_statistic",
     "options",
+    "authorization",
     "write_scopes",
     "read_scopes",
     "created_at",
     "updated_at"
   )(x => EventType.unapply(x).get)
 
-  implicit val eventTypeDecoder: Decoder[EventType] = Decoder.forProduct14(
+  implicit val eventTypeDecoder: Decoder[EventType] = Decoder.forProduct15(
     "name",
     "owning_application",
     "category",
@@ -221,6 +260,7 @@ object EventType {
     "partition_key_fields",
     "default_statistic",
     "options",
+    "authorization",
     "write_scopes",
     "read_scopes",
     "created_at",

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -35,35 +35,54 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
+case class SubscriptionAuthorization(admins: List[AuthorizationAttribute], readers: List[AuthorizationAttribute])
+
+object SubscriptionAuthorization {
+  implicit val subscriptionAuthorizationAuthorizationEncoder: Encoder[SubscriptionAuthorization] =
+    Encoder.forProduct2(
+      "admins",
+      "readers"
+    )(x => SubscriptionAuthorization.unapply(x).get)
+
+  implicit val subscriptionAuthorizationDecoder: Decoder[SubscriptionAuthorization] =
+    Decoder.forProduct2(
+      "admins",
+      "readers"
+    )(SubscriptionAuthorization.apply)
+}
+
 case class Subscription(id: Option[SubscriptionId],
                         owningApplication: String,
                         eventTypes: Option[List[EventTypeName]] = None,
                         consumerGroup: Option[String] = None,
                         createdAt: Option[OffsetDateTime] = None,
                         readFrom: Option[String] = None,
-                        initialCursors: Option[List[String]] = None)
+                        initialCursors: Option[List[String]] = None,
+                        authorization: Option[SubscriptionAuthorization] = None)
 
 object Subscription {
   implicit val subscriptionEncoder: Encoder[Subscription] =
-    Encoder.forProduct7(
+    Encoder.forProduct8(
       "id",
       "owning_application",
       "event_types",
       "consumer_group",
       "created_at",
       "read_from",
-      "initial_cursors"
+      "initial_cursors",
+      "authorization"
     )(x => Subscription.unapply(x).get)
 
   implicit val subscriptionDecoder: Decoder[Subscription] =
-    Decoder.forProduct7(
+    Decoder.forProduct8(
       "id",
       "owning_application",
       "event_types",
       "consumer_group",
       "created_at",
       "read_from",
-      "initial_cursors"
+      "initial_cursors",
+      "authorization"
     )(Subscription.apply)
 }
 

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -1092,6 +1092,7 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
                 case _                                     => false
               }
               cleanup(streamId, cancelledByClient)
+              ()
             })
             .map { data =>
               logger.debug(

--- a/src/test/scala/AuthorizationSpec.scala
+++ b/src/test/scala/AuthorizationSpec.scala
@@ -1,0 +1,108 @@
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
+import org.specs2.Specification
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers
+import org.specs2.specification.core.SpecStructure
+import org.zalando.kanadi.Config
+import org.zalando.kanadi.api._
+import org.zalando.kanadi.models.{EventTypeName, SubscriptionId}
+
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util.Success
+
+class AuthorizationSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
+  override def is: SpecStructure = sequential ^ s2"""
+    Create Event Type          $createEventType
+    Get Event Type             $getEventType
+    Create subscription        $createSubscription
+    Get subscription           $getSubscription
+    """
+
+  val config = ConfigFactory.load()
+
+  implicit val system       = ActorSystem()
+  implicit val http         = Http()
+  implicit val materializer = ActorMaterializer()
+
+  val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
+
+  eventTypeName.pp
+
+  val OwningApplication = "KANADI"
+
+  val consumerGroup = UUID.randomUUID().toString
+
+  s"Consumer Group: $consumerGroup".pp
+
+  val subscriptionsClient =
+    Subscriptions(nakadiUri, None)
+  val eventsClient = Events(nakadiUri, None)
+  val eventsTypesClient =
+    EventTypes(nakadiUri, None)
+
+  val currentSubscriptionId: Promise[SubscriptionId] = Promise()
+
+  val authorization = EventTypeAuthorization(
+    List(AuthorizationAttribute("user", "adminClientId")),
+    List(AuthorizationAttribute("user", "adminClientId")),
+    List(AuthorizationAttribute("user", "adminClientId"))
+  )
+
+  val subscriptionAuthorization = SubscriptionAuthorization(
+    List(AuthorizationAttribute("user", "adminClientId")),
+    List(AuthorizationAttribute("user", "adminClientId"))
+  )
+
+  def createEventType = (name: String) => {
+    val future = eventsTypesClient.create(
+      EventType(name = eventTypeName,
+                owningApplication = OwningApplication,
+                category = Category.Business,
+                authorization = Some(authorization)))
+
+    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+  }
+
+  def getEventType = (name: String) => {
+    val future = eventsTypesClient.get(eventTypeName).map(_.flatMap(_.authorization))
+    future must beSome(authorization).await(retries = 3, timeout = 10 seconds)
+  }
+
+  def createSubscription = (name: String) => {
+    val future = subscriptionsClient.createIfDoesntExist(
+      Subscription(
+        id = None,
+        owningApplication = OwningApplication,
+        eventTypes = Some(List(eventTypeName)),
+        consumerGroup = Some(consumerGroup),
+        authorization = Some(subscriptionAuthorization)
+      ))
+
+    future.onComplete {
+      case scala.util.Success(subscription) =>
+        subscription.id.pp
+        currentSubscriptionId.complete(Success(subscription.id.get))
+      case _ =>
+    }
+
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo(
+      (OwningApplication, Option(List(eventTypeName))))
+      .await(0, timeout = 5 seconds)
+  }
+
+  def getSubscription = (name: String) => {
+    val future = for {
+      subscriptionId <- currentSubscriptionId.future
+      subscription   <- subscriptionsClient.get(subscriptionId)
+    } yield subscription.flatMap(_.authorization)
+
+    future must beSome(subscriptionAuthorization).await(retries = 3, timeout = 10 seconds)
+  }
+
+}


### PR DESCRIPTION
This PR adds the authorization types, along with tests to make sure the decoders/encoders work.

Due to having to start Nakadi with an extra environment parameter (i.e. `NAKADI_PLUGINS_AUTHZ_FACTORY`) I added a docker-compose instead of us manually downloading it