### PR TITLE
nakadiUri of type URI should not be implicit

### DIFF
--- a/src/main/scala/org/zalando/kanadi/Config.scala
+++ b/src/main/scala/org/zalando/kanadi/Config.scala
@@ -10,7 +10,7 @@ import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
 trait Config {
   def config: com.typesafe.config.Config
 
-  implicit lazy val nakadiUri: URI = new URI(config.as[String]("kanadi.nakadi.uri"))
+  lazy val nakadiUri: URI = new URI(config.as[String]("kanadi.nakadi.uri"))
 
   implicit lazy val kanadiHttpConfig: HttpConfig = config.as[HttpConfig]("kanadi.http-config")
 }


### PR DESCRIPTION
We should not make basic types such as `URI` implicit (also there is no reason for this to be `implicit`, we pass the values directly)