### PR TITLE
Fix response when committing a bad cursor #39

### DIFF
--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -155,6 +155,30 @@ object SubscriptionStats {
     Decoder.forProduct1("items")(SubscriptionStats.apply)
 }
 
+final case class CommitCursorItemResponse(cursor: Subscriptions.Cursor, result: String)
+
+object CommitCursorItemResponse {
+  implicit val commitCursorsResponseDecoder: Decoder[CommitCursorItemResponse] = Decoder.forProduct2(
+    "cursor",
+    "result"
+  )(CommitCursorItemResponse.apply)
+
+  implicit val commitCursorsResponseEncoder: Encoder[CommitCursorItemResponse] = Encoder.forProduct2(
+    "cursor",
+    "result"
+  )(x => CommitCursorItemResponse.unapply(x).get)
+}
+
+final case class CommitCursorResponse(items: List[CommitCursorItemResponse])
+
+object CommitCursorResponse {
+  implicit val commitCursorsResponseDecoder: Decoder[CommitCursorResponse] =
+    Decoder.forProduct1("items")(CommitCursorResponse.apply)
+
+  implicit val commitCursorsResponseEncoder: Encoder[CommitCursorResponse] =
+    Encoder.forProduct1("items")(x => CommitCursorResponse.unapply(x).get)
+}
+
 object Subscriptions {
   protected val logger: LoggerTakingImplicit[FlowId] = Logger.takingImplicit[FlowId](Subscriptions.getClass)
   sealed abstract class Errors(problem: Problem) extends GeneralError(problem)
@@ -686,7 +710,7 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
   def commitCursors(subscriptionId: SubscriptionId, subscriptionCursor: SubscriptionCursor, streamId: StreamId)(
       implicit flowId: FlowId = randomFlowId(),
       executionContext: ExecutionContext
-  ): Future[Option[SubscriptionCursor]] = {
+  ): Future[Option[CommitCursorResponse]] = {
     val uri = baseUri_
       .withPath(baseUri_.path / "subscriptions" / subscriptionId.id.toString / "cursors")
 
@@ -711,8 +735,12 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
           Future.successful(None)
         } else if (response.status.isSuccess()) {
           Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
-            .to[SubscriptionCursor]
-            .map(x => Some(x))
+            .to[CommitCursorResponse]
+            .map { commitCursorsResponse =>
+              logger.warn(
+                s"SubscriptionId: ${subscriptionId.id.toString}, StreamId: ${streamId.id} At least one cursor failed to commit, details are $commitCursorsResponse")
+              Some(commitCursorsResponse)
+            }
         } else {
           processNotSuccessful(response)
         }

--- a/src/test/scala/BadJsonDecodingSpec.scala
+++ b/src/test/scala/BadJsonDecodingSpec.scala
@@ -71,11 +71,8 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
   val eventsTypesClient =
     EventTypes(nakadiUri, None)
 
-  private def randomFlowId(): FlowId =
-    FlowId(java.util.UUID.randomUUID().toString)
-
   def createEventType = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
 
@@ -90,7 +87,7 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
   val streamComplete: Promise[Boolean]               = Promise()
 
   def createSubscription = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = subscriptionsClient.createIfDoesntExist(
       Subscription(
@@ -128,7 +125,7 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
     }
 
   def startStreamBadEvents = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     def stream =
       for {
@@ -184,7 +181,7 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
   }
 
   def closeConnection = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val closedFuture = for {
       subscriptionId <- currentSubscriptionId.future
@@ -203,7 +200,7 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
   }
 
   def deleteSubscription = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = for {
       subscriptionId <- currentSubscriptionId.future
@@ -214,7 +211,7 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
   }
 
   def deleteEventType = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = eventsTypesClient.delete(eventTypeName)
 

--- a/src/test/scala/BasicSourceSpec.scala
+++ b/src/test/scala/BasicSourceSpec.scala
@@ -65,11 +65,8 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
   var eventCounter                                   = 0
   val streamComplete: Promise[Unit]                  = Promise()
 
-  private def randomFlowId(): FlowId =
-    FlowId(java.util.UUID.randomUUID().toString)
-
   def createSubscription = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = subscriptionsClient.createIfDoesntExist(
       Subscription(
@@ -92,7 +89,7 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
   }
 
   def startStreaming = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     def stream =
       for {
@@ -128,7 +125,7 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
   }
 
   def publishEvents = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val uUIDOne = java.util.UUID.randomUUID()
     val uUIDTwo = java.util.UUID.randomUUID()
@@ -152,7 +149,7 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
   }
 
   def closeConnection = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val closedFuture = for {
       subscriptionId <- currentSubscriptionId.future
@@ -165,7 +162,7 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
   }
 
   def deleteSubscription = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = for {
       subscriptionId <- currentSubscriptionId.future
@@ -176,7 +173,7 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
   }
 
   def deleteEventType = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = eventsTypesClient.delete(eventTypeName)
 

--- a/src/test/scala/BasicSpec.scala
+++ b/src/test/scala/BasicSpec.scala
@@ -72,11 +72,8 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
   val subscriptionClosed: AtomicBoolean              = new AtomicBoolean(false)
   val streamComplete: Promise[Unit]                  = Promise()
 
-  private def randomFlowId(): FlowId =
-    FlowId(java.util.UUID.randomUUID().toString)
-
   def createSubscription = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = subscriptionsClient.createIfDoesntExist(
       Subscription(
@@ -99,7 +96,7 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
   }
 
   def publishEvents = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val uUIDOne = java.util.UUID.randomUUID()
     val uUIDTwo = java.util.UUID.randomUUID()
@@ -119,7 +116,7 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
   }
 
   def startStreaming = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     def stream =
       for {
@@ -163,7 +160,7 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
   }
 
   def getSubscriptionStats = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
 
     val statsPresent = for {
@@ -175,7 +172,7 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
   }
 
   def closeConnection = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val closedFuture = for {
       subscriptionId <- currentSubscriptionId.future
@@ -194,7 +191,7 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
   }
 
   def deleteSubscription = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = for {
       subscriptionId <- currentSubscriptionId.future
@@ -205,7 +202,7 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
   }
 
   def deleteEventType = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     val future = eventsTypesClient.delete(eventTypeName)
 

--- a/src/test/scala/CommitCursorBadResponseSpec.scala
+++ b/src/test/scala/CommitCursorBadResponseSpec.scala
@@ -1,0 +1,109 @@
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import com.typesafe.config.ConfigFactory
+import io.circe.JsonObject
+import org.mdedetrich.webmodels.FlowId
+import org.specs2.Specification
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers
+import org.specs2.specification.core.SpecStructure
+import org.zalando.kanadi.Config
+import org.zalando.kanadi.api._
+import org.zalando.kanadi.models.{EventTypeName, SubscriptionId}
+
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util._
+
+class CommitCursorBadResponseSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
+  override def is: SpecStructure = sequential ^ s2"""
+    Create Event Type          $createEventType
+    Create Subscription events $createSubscription
+    Stream subscritpion        $streamSubscriptionId
+  """
+
+  val config = ConfigFactory.load()
+
+  implicit val system       = ActorSystem()
+  implicit val http         = Http()
+  implicit val materializer = ActorMaterializer()
+
+  val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
+
+  eventTypeName.pp
+
+  val OwningApplication = "KANADI"
+
+  val consumerGroup = UUID.randomUUID().toString
+
+  s"Consumer Group: $consumerGroup".pp
+
+  val subscriptionsClient =
+    Subscriptions(nakadiUri, None)
+  val eventsClient = Events(nakadiUri, None)
+  val eventsTypesClient =
+    EventTypes(nakadiUri, None)
+
+  val currentSubscriptionId: Promise[SubscriptionId]                             = Promise()
+  val successfullyParsedBadCommitResponse: Promise[Option[CommitCursorResponse]] = Promise()
+
+  def createEventType = (name: String) => {
+    val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
+
+    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+  }
+
+  def createSubscription = (name: String) => {
+    implicit val flowId: FlowId = Utils.randomFlowId()
+    flowId.pp(name)
+    val future = subscriptionsClient.createIfDoesntExist(
+      Subscription(
+        None,
+        OwningApplication,
+        Option(List(eventTypeName)),
+        Option(consumerGroup)
+      ))
+
+    future.onComplete {
+      case Success(subscription) =>
+        subscription.id.pp
+        currentSubscriptionId.complete(Success(subscription.id.get))
+      case _ =>
+    }
+
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo(
+      (OwningApplication, Option(List(eventTypeName))))
+      .await(0, timeout = 5 seconds)
+  }
+
+  def streamSubscriptionId = (name: String) => {
+    implicit val flowId: FlowId = Utils.randomFlowId()
+    flowId.pp(name)
+
+    val future = for {
+      subscriptionId <- currentSubscriptionId.future
+      _ = subscriptionsClient.eventsStreamedSource[JsonObject](subscriptionId).map { nakadiSource =>
+        nakadiSource.source
+          .map { subscriptionEvent =>
+            subscriptionsClient
+              .commitCursors(subscriptionId, SubscriptionCursor(List(subscriptionEvent.cursor)), nakadiSource.streamId)
+              .onComplete {
+                case Success(response) =>
+                  successfullyParsedBadCommitResponse.complete(Success(response))
+                case Failure(e) =>
+                  successfullyParsedBadCommitResponse.complete(Failure(e))
+              }
+
+          }
+          .runWith(Sink.foreach(_ => ()))
+      }
+      result <- successfullyParsedBadCommitResponse.future
+    } yield result
+
+    future must beSome.await(0, timeout = 2 minutes)
+  }
+}

--- a/src/test/scala/OAuthFailedSpec.scala
+++ b/src/test/scala/OAuthFailedSpec.scala
@@ -35,18 +35,16 @@ class OAuthFailedSpec(implicit ec: ExecutionEnv) extends Specification with Futu
     Call to publishEvents should fail with invalid token        $oAuthPublishEvents
   """
 
-  private def randomFlowId(): FlowId =
-    FlowId(java.util.UUID.randomUUID().toString)
 
   def oAuthCallSubscriptions = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     subscriptionsClient.list() must throwA[GeneralError]
       .await(0, timeout = 3 seconds)
   }
 
   def oAuthPublishEvents = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
     eventsClient
       .publish[Json](EventTypeName("Test"), List.empty) must throwA[GeneralError]

--- a/src/test/scala/SubscriptionsSpec.scala
+++ b/src/test/scala/SubscriptionsSpec.scala
@@ -41,8 +41,6 @@ class SubscriptionsSpec(implicit ec: ExecutionEnv) extends Specification with Co
   eventTypeName.pp
   s"Consumer Group: $consumerGroup".pp
 
-  private def randomFlowId(): FlowId =
-    FlowId(java.util.UUID.randomUUID().toString)
   def createEventType = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
 
   override def beforeAll = {
@@ -57,10 +55,11 @@ class SubscriptionsSpec(implicit ec: ExecutionEnv) extends Specification with Co
       } yield (res1, res2),
       10 seconds
     )
+    ()
   }
 
   def createEnoughSubscriptionsToUsePagination = (name: String) => {
-    implicit val flowId: FlowId = randomFlowId()
+    implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
 
     val createdSubscriptions = Future.sequence(for {

--- a/src/test/scala/Utils.scala
+++ b/src/test/scala/Utils.scala
@@ -1,0 +1,6 @@
+import org.mdedetrich.webmodels.FlowId
+
+object Utils {
+  def randomFlowId(): FlowId =
+    FlowId(java.util.UUID.randomUUID().toString)
+}


### PR DESCRIPTION
This PR fixes #39 .

The issue is that we got the response body wrong, hence the change from `Option[SubscriptionCursor]` to `Option[CommitCursorResponse]`. Note that you typically would never get this response in production because it only happens when you try to commit an invalid cursor. For the same reason we also log a warn statement stating that something is possibly wrong.

A test has been added to verify that we got the response decoder correct.

PR also does some cleanup on the test code