### PR TITLE
Bump Scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 scala:
   - 2.11.12
-  - 2.12.6
+  - 2.12.7
 
 jdk: oraclejdk8
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,12 @@ val akkaVersion            = "2.5.12"
 
 scalaVersion in ThisBuild := currentScalaVersion
 
-crossScalaVersions in ThisBuild := Seq(currentScalaVersion, "2.12.6")
+crossScalaVersions in ThisBuild := Seq(currentScalaVersion, "2.12.7")
 
 organization := "org.zalando"
 
-javaOptions in Test += "-DTOKEN=" + Option(System.getProperty("TOKEN"))
-  .getOrElse("")
-
-fork in Test := true
+fork in Test := false
+parallelExecution in Test := true
 
 updateOptions := updateOptions.value.withGigahorse(false)
 
@@ -46,7 +44,7 @@ val flagsFor11 = Seq(
 val flagsFor12 = Seq(
   "-Xlint:_",
   "-Ywarn-infer-any",
-  "-opt:l:project"
+  "-opt-inline-from:<sources>"
 )
 
 scalacOptions ++= {
@@ -86,7 +84,8 @@ scmInfo := Some(
 developers := List(
   Developer("mdedetrich", "Matthew de Detrich", "mdedetrich@gmail.com", url("https://github.com/mdedetrich")),
   Developer("xjrk58", "Jiri Syrovy", "jiri.syrovy@zalando.de", url("https://github.com/xjrk58")),
-  Developer("itachi3", "Balaji Sonachalam", "balajispsg@gmail.com", url("https://github.com/itachi3"))
+  Developer("itachi3", "Balaji Sonachalam", "balajispsg@gmail.com", url("https://github.com/itachi3")),
+  Developer("Deeds67", "Pierre Marais", "pierrem@live.co.za", url("https://github.com/Deeds67"))
 )
 
 licenses += ("MIT", url("https://opensource.org/licenses/MIT"))


### PR DESCRIPTION
This PR bumps Scala version as well as improving speed of tests (turns out we don't need to fork). Also added @Deeds67 as a developer plus removed depreciation message with  `"-opt-inline-from:<sources>"`.

The PR saves ~3-4 minutes off the build time