### PR TITLE
Remove .withIdleTimeout #37

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,9 @@ crossScalaVersions in ThisBuild := Seq(currentScalaVersion, "2.12.7")
 
 organization := "org.zalando"
 
-fork in Test := false
+fork in Test := true
 parallelExecution in Test := true
+testForkedParallel in Test := true
 
 updateOptions := updateOptions.value.withGigahorse(false)
 

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -1040,23 +1040,13 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
       request = HttpRequest(HttpMethods.GET, uri, headers)
       _       = logger.debug(request.toString)
 
-      connectionPoolSettings = ConnectionPoolSettings(http.system)
-      clientConnectionSettings = connectionPoolSettings.connectionSettings
-        .withIdleTimeout(
-          streamConfig.streamTimeout match {
-            case Some(finiteDuration) => finiteDuration * 1.1
-            case None                 => Duration.Inf
-          }
-        )
-
       // Create a single connection to avoid the pool
-
       connectionFlow = {
         val host = baseUri_.authority.host.toString()
         val port = baseUri_.effectivePort
         if (request.uri.scheme.equalsIgnoreCase("https"))
-          http.outgoingConnectionHttps(host = host, port = port, settings = clientConnectionSettings)
-        else http.outgoingConnection(host = host, port = port, settings = clientConnectionSettings)
+          http.outgoingConnectionHttps(host = host, port = port)
+        else http.outgoingConnection(host = host, port = port)
       }
 
       response <- Source


### PR DESCRIPTION
This PR is an attempt to solve #37 . This is the simplest solution initially and should theoretically work. I am going to monitor to see if this happens again.

EDIT: So it turns out that I have figured out the actual issue, which was using `withIdleTimeout`. The old code looked like this

```scala
      clientConnectionSettings = connectionPoolSettings.connectionSettings
        .withIdleTimeout(
          streamConfig.streamTimeout match {
            case Some(finiteDuration) => finiteDuration * 1.1
            case None                 => Duration.Inf
          }
        )
```

Since this value was typically never set, the idle timeout was set to infinity. Unfortunately in some cases, Nakadi would would never send the initial http response which is what caused the kanadi to hang forever.

The reason why `.withIdleTimeout` was set is that initially I was under the impression it was needed because if no events are sent we don't want the stream to terminate. Turns out this timeout is only for the initial http status/headers and not as the response is being streamed, so its not needed.

The PR also re-enables forking, looks like it was needed due to an SBT bug, however using `testForkedParallel` means that the test performance shouldn't degrade too much.