### PR TITLE
Make case classes final

### DIFF
--- a/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
@@ -88,10 +88,10 @@ object CompatibilityMode extends Enum[CompatibilityMode] {
     enumeratum.Circe.decoder(CompatibilityMode)
 }
 
-case class EventTypeSchema(version: Option[String],
-                           createdAt: Option[OffsetDateTime],
-                           `type`: EventTypeSchema.Type,
-                           schema: Json)
+final case class EventTypeSchema(version: Option[String],
+                                 createdAt: Option[OffsetDateTime],
+                                 `type`: EventTypeSchema.Type,
+                                 schema: Json)
 
 object EventTypeSchema {
 
@@ -124,7 +124,10 @@ object EventTypeSchema {
     Decoder.forProduct4("version", "created_at", "type", "schema")(EventTypeSchema.apply)
 }
 
-case class EventTypeStatistics(messagesPerMinute: Int, messageSize: Int, readParallelism: Int, writeParallelism: Int)
+final case class EventTypeStatistics(messagesPerMinute: Int,
+                                     messageSize: Int,
+                                     readParallelism: Int,
+                                     writeParallelism: Int)
 
 object EventTypeStatistics {
   implicit val eventTypeStatisticsEncoder: Encoder[EventTypeStatistics] =
@@ -144,7 +147,7 @@ object EventTypeStatistics {
     )(EventTypeStatistics.apply)
 }
 
-case class AuthorizationAttribute(dataType: String, value: String)
+final case class AuthorizationAttribute(dataType: String, value: String)
 
 object AuthorizationAttribute {
   implicit val eventTypeAuthorizationAuthorizationAttributeEncoder: Encoder[AuthorizationAttribute] =
@@ -160,9 +163,9 @@ object AuthorizationAttribute {
     )(AuthorizationAttribute.apply)
 }
 
-case class EventTypeAuthorization(admins: List[AuthorizationAttribute],
-                                  readers: List[AuthorizationAttribute],
-                                  writers: List[AuthorizationAttribute])
+final case class EventTypeAuthorization(admins: List[AuthorizationAttribute],
+                                        readers: List[AuthorizationAttribute],
+                                        writers: List[AuthorizationAttribute])
 
 object EventTypeAuthorization {
   implicit val eventTypeAuthorizationEncoder: Encoder[EventTypeAuthorization] =
@@ -180,7 +183,7 @@ object EventTypeAuthorization {
     )(EventTypeAuthorization.apply)
 }
 
-case class EventTypeOptions(retentionTime: Int)
+final case class EventTypeOptions(retentionTime: Int)
 
 object EventTypeOptions {
   implicit val eventTypeOptionsEncoder: Encoder[EventTypeOptions] =
@@ -212,7 +215,7 @@ object EventTypeOptions {
   * @param createdAt Date and time when this event type was created.
   * @param updatedAt Date and time when this event type was last updated.
   */
-case class EventType(
+final case class EventType(
     name: EventTypeName,
     owningApplication: String,
     category: Category,

--- a/src/main/scala/org/zalando/kanadi/api/Events.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Events.scala
@@ -29,7 +29,10 @@ import scala.concurrent.{ExecutionContext, Future}
 sealed abstract class Event[T](val data: T)
 
 object Event {
-  case class DataChange[T](override val data: T, dataType: String, dataOperation: DataOperation, metadata: Metadata)
+  final case class DataChange[T](override val data: T,
+                                 dataType: String,
+                                 dataOperation: DataOperation,
+                                 metadata: Metadata)
       extends Event[T](data)
 
   object DataChange {
@@ -50,7 +53,7 @@ object Event {
       )(DataChange.apply)
   }
 
-  case class Business[T](override val data: T, metadata: Metadata = Metadata()) extends Event[T](data)
+  final case class Business[T](override val data: T, metadata: Metadata = Metadata()) extends Event[T](data)
 
   object Business {
     implicit def eventBusinessEncoder[T](implicit encoder: Encoder[T]): Encoder[Business[T]] =
@@ -73,7 +76,7 @@ object Event {
       }
   }
 
-  case class Undefined[T](override val data: T) extends Event[T](data)
+  final case class Undefined[T](override val data: T) extends Event[T](data)
 
   object Undefined {
     implicit def eventUndefinedEncoder[T](implicit encoder: Encoder[T]): Encoder[Undefined[T]] =
@@ -138,13 +141,13 @@ object DataOperation extends Enum[DataOperation] {
     enumeratum.Circe.decoder(DataOperation)
 }
 
-case class Metadata(eid: EventId = EventId.random,
-                    occurredAt: OffsetDateTime = OffsetDateTime.now,
-                    eventType: Option[EventTypeName] = None,
-                    receivedAt: Option[OffsetDateTime] = None,
-                    parentEids: Option[List[EventId]] = None,
-                    flowId: Option[FlowId] = None,
-                    partition: Option[Partition] = None)
+final case class Metadata(eid: EventId = EventId.random,
+                          occurredAt: OffsetDateTime = OffsetDateTime.now,
+                          eventType: Option[EventTypeName] = None,
+                          receivedAt: Option[OffsetDateTime] = None,
+                          parentEids: Option[List[EventId]] = None,
+                          flowId: Option[FlowId] = None,
+                          partition: Option[Partition] = None)
 
 object Metadata {
 
@@ -170,10 +173,10 @@ object Metadata {
 }
 
 object Events {
-  case class BatchItemResponse(eid: Option[EventId],
-                               publishingStatus: PublishingStatus,
-                               step: Option[Step],
-                               detail: Option[String])
+  final case class BatchItemResponse(eid: Option[EventId],
+                                     publishingStatus: PublishingStatus,
+                                     step: Option[Step],
+                                     detail: Option[String])
 
   object BatchItemResponse {
     implicit val batchItemResponseEncoder: Encoder[BatchItemResponse] =
@@ -230,7 +233,7 @@ object Events {
   sealed abstract class Errors extends Exception
 
   object Errors {
-    case class EventValidation(batchItemResponse: List[BatchItemResponse]) extends Errors {
+    final case class EventValidation(batchItemResponse: List[BatchItemResponse]) extends Errors {
       override def getMessage: String =
         s"Error publishing events, errors are ${batchItemResponse.mkString("\n")}"
     }

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Connection, RawHeader}
-import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream._
 import akka.stream.scaladsl._
@@ -31,12 +30,12 @@ import org.mdedetrich.webmodels.circe._
 import org.zalando.kanadi.models
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
-case class SubscriptionAuthorization(admins: List[AuthorizationAttribute], readers: List[AuthorizationAttribute])
+final case class SubscriptionAuthorization(admins: List[AuthorizationAttribute], readers: List[AuthorizationAttribute])
 
 object SubscriptionAuthorization {
   implicit val subscriptionAuthorizationAuthorizationEncoder: Encoder[SubscriptionAuthorization] =
@@ -52,14 +51,14 @@ object SubscriptionAuthorization {
     )(SubscriptionAuthorization.apply)
 }
 
-case class Subscription(id: Option[SubscriptionId],
-                        owningApplication: String,
-                        eventTypes: Option[List[EventTypeName]] = None,
-                        consumerGroup: Option[String] = None,
-                        createdAt: Option[OffsetDateTime] = None,
-                        readFrom: Option[String] = None,
-                        initialCursors: Option[List[String]] = None,
-                        authorization: Option[SubscriptionAuthorization] = None)
+final case class Subscription(id: Option[SubscriptionId],
+                              owningApplication: String,
+                              eventTypes: Option[List[EventTypeName]] = None,
+                              consumerGroup: Option[String] = None,
+                              createdAt: Option[OffsetDateTime] = None,
+                              readFrom: Option[String] = None,
+                              initialCursors: Option[List[String]] = None,
+                              authorization: Option[SubscriptionAuthorization] = None)
 
 object Subscription {
   implicit val subscriptionEncoder: Encoder[Subscription] =
@@ -87,7 +86,7 @@ object Subscription {
     )(Subscription.apply)
 }
 
-case class SubscriptionQuery(links: PaginationLinks, items: List[Subscription])
+final case class SubscriptionQuery(links: PaginationLinks, items: List[Subscription])
 
 object SubscriptionQuery {
   implicit val subscriptionQueryEncoder: Encoder[SubscriptionQuery] =
@@ -103,7 +102,7 @@ object SubscriptionQuery {
     )(SubscriptionQuery.apply)
 }
 
-case class SubscriptionCursor(items: List[Subscriptions.Cursor])
+final case class SubscriptionCursor(items: List[Subscriptions.Cursor])
 
 object SubscriptionCursor {
   implicit val subscriptionCursorEncoder: Encoder[SubscriptionCursor] =
@@ -113,7 +112,7 @@ object SubscriptionCursor {
     Decoder.forProduct1("items")(SubscriptionCursor.apply)
 }
 
-case class SubscriptionEventInfo(cursor: Subscriptions.Cursor, info: Option[JsonObject])
+final case class SubscriptionEventInfo(cursor: Subscriptions.Cursor, info: Option[JsonObject])
 
 object SubscriptionEventInfo {
   implicit val subscriptionEventInfoEncoder: Encoder[SubscriptionEventInfo] =
@@ -129,7 +128,7 @@ object SubscriptionEventInfo {
     )(SubscriptionEventInfo.apply)
 }
 
-case class SubscriptionEventData[T](events: Option[List[Event[T]]])
+final case class SubscriptionEventData[T](events: Option[List[Event[T]]])
 
 object SubscriptionEventData {
   implicit def subscriptionEventDataEncoder[T](
@@ -145,7 +144,9 @@ object SubscriptionEventData {
     )(SubscriptionEventData.apply)
 }
 
-case class SubscriptionEvent[T](cursor: Subscriptions.Cursor, info: Option[JsonObject], events: Option[List[Event[T]]])
+final case class SubscriptionEvent[T](cursor: Subscriptions.Cursor,
+                                      info: Option[JsonObject],
+                                      events: Option[List[Event[T]]])
 
 object SubscriptionEvent {
 
@@ -164,7 +165,7 @@ object SubscriptionEvent {
     )(SubscriptionEvent.apply)
 }
 
-case class SubscriptionStats(items: List[Subscriptions.EventTypeStats])
+final case class SubscriptionStats(items: List[Subscriptions.EventTypeStats])
 
 object SubscriptionStats {
   implicit val subscriptionStatsEncoder: Encoder[SubscriptionStats] =
@@ -203,17 +204,20 @@ object Subscriptions {
   sealed abstract class Errors(problem: Problem) extends GeneralError(problem)
 
   object Errors {
-    case class NoEmptySlotsOrCursorReset(override val problem: Problem) extends Errors(problem)
-    case class SubscriptionNotFound(override val problem: Problem)      extends Errors(problem)
+    final case class NoEmptySlotsOrCursorReset(override val problem: Problem) extends Errors(problem)
+    final case class SubscriptionNotFound(override val problem: Problem)      extends Errors(problem)
   }
 
-  case class EventJsonParsingException(subscriptionEventInfo: SubscriptionEventInfo,
-                                       jsonParsingException: CirceStreamSupport.JsonParsingException)
+  final case class EventJsonParsingException(subscriptionEventInfo: SubscriptionEventInfo,
+                                             jsonParsingException: CirceStreamSupport.JsonParsingException)
       extends Exception {
     override def getMessage: String = jsonParsingException.getMessage
   }
 
-  case class Cursor(partition: models.Partition, offset: String, eventType: EventTypeName, cursorToken: CursorToken)
+  final case class Cursor(partition: models.Partition,
+                          offset: String,
+                          eventType: EventTypeName,
+                          cursorToken: CursorToken)
 
   object Cursor {
     implicit val subscriptionEventCursorEncoder: Encoder[Cursor] =
@@ -223,15 +227,15 @@ object Subscriptions {
 
   }
 
-  case class EventTypeStats(eventType: EventTypeName, partitions: List[EventTypeStats.Partition])
+  final case class EventTypeStats(eventType: EventTypeName, partitions: List[EventTypeStats.Partition])
 
   object EventTypeStats {
-    case class Partition(partition: models.Partition,
-                         state: Partition.State,
-                         unconsumedEvents: Option[Int],
-                         consumerLagSeconds: Option[FiniteDuration],
-                         streamId: Option[StreamId],
-                         assignmentType: Option[Partition.AssignmentType])
+    final case class Partition(partition: models.Partition,
+                               state: Partition.State,
+                               unconsumedEvents: Option[Int],
+                               consumerLagSeconds: Option[FiniteDuration],
+                               streamId: Option[StreamId],
+                               assignmentType: Option[Partition.AssignmentType])
 
     object Partition {
       sealed abstract class State(val id: String) extends EnumEntry with Product with Serializable {
@@ -316,10 +320,10 @@ object Subscriptions {
     *               else it will use the flowId used when [[Subscriptions.eventsStreamed]] is called
     * @tparam T
     */
-  case class EventCallbackData[T](subscriptionEvent: SubscriptionEvent[T],
-                                  streamId: StreamId,
-                                  request: HttpRequest,
-                                  flowId: Option[FlowId])
+  final case class EventCallbackData[T](subscriptionEvent: SubscriptionEvent[T],
+                                        streamId: StreamId,
+                                        request: HttpRequest,
+                                        flowId: Option[FlowId])
 
   /**
     *
@@ -340,7 +344,7 @@ object Subscriptions {
       * @param eventCallback
       * @tparam T
       */
-    case class simple[T](eventCallback: EventCallbackData[T] => Unit, override val separateFlowId: Boolean = true)
+    final case class simple[T](eventCallback: EventCallbackData[T] => Unit, override val separateFlowId: Boolean = true)
         extends EventCallback[T](separateFlowId)
 
     /**
@@ -348,8 +352,8 @@ object Subscriptions {
       * @param eventCallback
       * @tparam T
       */
-    case class successAlways[T](eventCallback: EventCallbackData[T] => Unit,
-                                override val separateFlowId: Boolean = true)
+    final case class successAlways[T](eventCallback: EventCallbackData[T] => Unit,
+                                      override val separateFlowId: Boolean = true)
         extends EventCallback[T](separateFlowId)
 
     /**
@@ -357,27 +361,27 @@ object Subscriptions {
       * @param eventCallback
       * @tparam T
       */
-    case class successPredicate[T](eventCallback: EventCallbackData[T] => Boolean,
-                                   override val separateFlowId: Boolean = true)
-        extends EventCallback[T](separateFlowId)
-
-    /**
-      * Executes the callback in a try-catch block, only submitting the cursor if the predicate evaluates to true
-      * @param eventCallback
-      * @tparam T
-      */
-    case class successPredicateFuture[T](eventCallback: EventCallbackData[T] => Future[Boolean],
+    final case class successPredicate[T](eventCallback: EventCallbackData[T] => Boolean,
                                          override val separateFlowId: Boolean = true)
+        extends EventCallback[T](separateFlowId)
+
+    /**
+      * Executes the callback in a try-catch block, only submitting the cursor if the predicate evaluates to true
+      * @param eventCallback
+      * @tparam T
+      */
+    final case class successPredicateFuture[T](eventCallback: EventCallbackData[T] => Future[Boolean],
+                                               override val separateFlowId: Boolean = true)
         extends EventCallback[T](separateFlowId)
 
   }
 
-  case class ConnectionClosedData(occurredAt: OffsetDateTime,
-                                  subscriptionId: SubscriptionId,
-                                  oldStreamId: StreamId,
-                                  cancelledByClient: Boolean)
+  final case class ConnectionClosedData(occurredAt: OffsetDateTime,
+                                        subscriptionId: SubscriptionId,
+                                        oldStreamId: StreamId,
+                                        cancelledByClient: Boolean)
 
-  case class ConnectionClosedCallback(connectionClosedCallback: ConnectionClosedData => Unit)
+  final case class ConnectionClosedCallback(connectionClosedCallback: ConnectionClosedData => Unit)
 
   /**
     *
@@ -386,12 +390,13 @@ object Subscriptions {
     * @param streamId Current Stream Id
     * @param subscriptionsClient the current subscription client that is being used
     */
-  case class EventStreamContext(flowId: FlowId,
-                                subscriptionId: SubscriptionId,
-                                streamId: StreamId,
-                                subscriptionsClient: Subscriptions)
+  final case class EventStreamContext(flowId: FlowId,
+                                      subscriptionId: SubscriptionId,
+                                      streamId: StreamId,
+                                      subscriptionsClient: Subscriptions)
 
-  case class EventStreamSupervisionDecider(private val privateDecider: EventStreamContext => Supervision.Decider) {
+  final case class EventStreamSupervisionDecider(
+      private val privateDecider: EventStreamContext => Supervision.Decider) {
     def decider(eventStreamContext: EventStreamContext): Supervision.Decider =
       privateDecider(eventStreamContext)
   }
@@ -456,6 +461,14 @@ object Subscriptions {
                                    source: Source[SubscriptionEvent[T], UniqueKillSwitch],
                                    request: HttpRequest)
 
+}
+
+/**
+  * Exception that is passed if the stream is cancelled by the client
+  */
+final case class CancelledByClient(subscriptionId: SubscriptionId, streamId: StreamId) extends Exception {
+  override def getMessage =
+    s"Stream cancelled by client SubscriptionId: ${subscriptionId.id}, StreamId: ${streamId.id}"
 }
 
 case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvider] = None)(
@@ -1413,14 +1426,6 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
               streamConfig
             ))
       }
-  }
-
-  /**
-    * Exception that is passed if the stream is cancelled by the client
-    */
-  case class CancelledByClient(subscriptionId: SubscriptionId, streamId: StreamId) extends Exception {
-    override def getMessage =
-      s"Stream cancelled by client SubscriptionId: ${subscriptionId.id}, StreamId: ${streamId.id}"
   }
 
   /**

--- a/src/main/scala/org/zalando/kanadi/api/package.scala
+++ b/src/main/scala/org/zalando/kanadi/api/package.scala
@@ -42,8 +42,7 @@ package object api {
     }
   }
 
-  private[api] def toHeader(oAuth2Token: OAuth2Token)(
-      implicit kanadiHttpConfig: HttpConfig): HttpHeader = {
+  private[api] def toHeader(oAuth2Token: OAuth2Token)(implicit kanadiHttpConfig: HttpConfig): HttpHeader = {
     if (kanadiHttpConfig.censorOAuth2Token)
       CensoredRawHeader("Authorization", s"Bearer ${oAuth2Token.token}", "Bearer <secret>")
     else RawHeader("Authorization", s"Bearer ${oAuth2Token.token}")

--- a/src/main/scala/org/zalando/kanadi/models/BasicServerError.scala
+++ b/src/main/scala/org/zalando/kanadi/models/BasicServerError.scala
@@ -2,7 +2,7 @@ package org.zalando.kanadi.models
 
 import io.circe.{Decoder, Encoder}
 
-case class BasicServerError(error: String, errorDescription: String)
+final case class BasicServerError(error: String, errorDescription: String)
 
 object BasicServerError {
   implicit val basicServerErrorEncoder: Encoder[BasicServerError] =

--- a/src/main/scala/org/zalando/kanadi/models/CursorToken.scala
+++ b/src/main/scala/org/zalando/kanadi/models/CursorToken.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-case class CursorToken(id: UUID) extends AnyVal
+final case class CursorToken(id: UUID) extends AnyVal
 
 object CursorToken {
   implicit val cursorTokenEncoder: Encoder[CursorToken] =

--- a/src/main/scala/org/zalando/kanadi/models/CustomHeaders.scala
+++ b/src/main/scala/org/zalando/kanadi/models/CustomHeaders.scala
@@ -2,7 +2,7 @@ package org.zalando.kanadi.models
 
 import akka.http.scaladsl.model.headers.RawHeader
 
-case class CustomHeaders(headers: Map[String, String]) extends AnyVal {
+final case class CustomHeaders(headers: Map[String, String]) extends AnyVal {
   def toRawHeaders: List[RawHeader] = {
     headers.to[List].map { case (k, v) => RawHeader(k, v) }
   }

--- a/src/main/scala/org/zalando/kanadi/models/EventId.scala
+++ b/src/main/scala/org/zalando/kanadi/models/EventId.scala
@@ -3,7 +3,7 @@ package org.zalando.kanadi.models
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-case class EventId(id: String) extends AnyVal
+final case class EventId(id: String) extends AnyVal
 
 object EventId {
   implicit val eventIdEncoder: Encoder[EventId] =

--- a/src/main/scala/org/zalando/kanadi/models/EventTypeName.scala
+++ b/src/main/scala/org/zalando/kanadi/models/EventTypeName.scala
@@ -3,7 +3,7 @@ package org.zalando.kanadi.models
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-case class EventTypeName(name: String) extends AnyVal
+final case class EventTypeName(name: String) extends AnyVal
 
 object EventTypeName {
   implicit val eventTypeNameEncoder: Encoder[EventTypeName] =

--- a/src/main/scala/org/zalando/kanadi/models/GeneralError.scala
+++ b/src/main/scala/org/zalando/kanadi/models/GeneralError.scala
@@ -7,7 +7,7 @@ class GeneralError(val problem: Problem) extends Exception {
   override def getMessage: String = s"Error from server, response is $problem"
 }
 
-case class OtherError(error: BasicServerError) extends Exception {
+final case class OtherError(error: BasicServerError) extends Exception {
   override def getMessage: String = s"Error from server, response is $error"
 }
 

--- a/src/main/scala/org/zalando/kanadi/models/HttpConfig.scala
+++ b/src/main/scala/org/zalando/kanadi/models/HttpConfig.scala
@@ -2,8 +2,8 @@ package org.zalando.kanadi.models
 
 import scala.concurrent.duration.FiniteDuration
 
-case class HttpConfig(censorOAuth2Token: Boolean,
-                      singleStringChunkLength: Int,
-                      eventListChunkLength: Int,
-                      noEmptySlotsCursorResetRetryDelay: FiniteDuration,
-                      serverDisconnectRetryDelay: FiniteDuration)
+final case class HttpConfig(censorOAuth2Token: Boolean,
+                            singleStringChunkLength: Int,
+                            eventListChunkLength: Int,
+                            noEmptySlotsCursorResetRetryDelay: FiniteDuration,
+                            serverDisconnectRetryDelay: FiniteDuration)

--- a/src/main/scala/org/zalando/kanadi/models/PaginationLink.scala
+++ b/src/main/scala/org/zalando/kanadi/models/PaginationLink.scala
@@ -4,7 +4,7 @@ package models
 import java.net.URI
 import io.circe.{Decoder, Encoder}
 
-case class PaginationLink(href: URI) extends AnyVal
+final case class PaginationLink(href: URI) extends AnyVal
 
 object PaginationLink {
   implicit val linkEncoder: Encoder[PaginationLink] =

--- a/src/main/scala/org/zalando/kanadi/models/PaginationLinks.scala
+++ b/src/main/scala/org/zalando/kanadi/models/PaginationLinks.scala
@@ -3,7 +3,7 @@ package models
 
 import io.circe.{Decoder, Encoder}
 
-case class PaginationLinks(prev: Option[PaginationLink], next: Option[PaginationLink])
+final case class PaginationLinks(prev: Option[PaginationLink], next: Option[PaginationLink])
 
 object PaginationLinks {
   implicit val paginationLinksEncoder: Encoder[PaginationLinks] =

--- a/src/main/scala/org/zalando/kanadi/models/Partition.scala
+++ b/src/main/scala/org/zalando/kanadi/models/Partition.scala
@@ -3,7 +3,7 @@ package org.zalando.kanadi.models
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-case class Partition(id: String) extends AnyVal
+final case class Partition(id: String) extends AnyVal
 
 object Partition {
   implicit val partitionEncoder: Encoder[Partition] = Encoder.instance[Partition](_.id.asJson)

--- a/src/main/scala/org/zalando/kanadi/models/ReadScope.scala
+++ b/src/main/scala/org/zalando/kanadi/models/ReadScope.scala
@@ -3,7 +3,7 @@ package org.zalando.kanadi.models
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-case class ReadScope(id: String) extends AnyVal
+final case class ReadScope(id: String) extends AnyVal
 
 object ReadScope {
   implicit val readScopeEncoder: Encoder[ReadScope] =

--- a/src/main/scala/org/zalando/kanadi/models/StreamId.scala
+++ b/src/main/scala/org/zalando/kanadi/models/StreamId.scala
@@ -4,7 +4,7 @@ package models
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-case class StreamId(id: String) extends AnyVal
+final case class StreamId(id: String) extends AnyVal
 
 object StreamId {
   implicit val streamIdEncoder: Encoder[StreamId] =

--- a/src/main/scala/org/zalando/kanadi/models/SubscriptionId.scala
+++ b/src/main/scala/org/zalando/kanadi/models/SubscriptionId.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-case class SubscriptionId(id: UUID) extends AnyVal
+final case class SubscriptionId(id: UUID) extends AnyVal
 
 object SubscriptionId {
   implicit val subscriptionIdEncoder: Encoder[SubscriptionId] =

--- a/src/main/scala/org/zalando/kanadi/models/WriteScope.scala
+++ b/src/main/scala/org/zalando/kanadi/models/WriteScope.scala
@@ -3,7 +3,7 @@ package org.zalando.kanadi.models
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-case class WriteScope(id: String) extends AnyVal
+final case class WriteScope(id: String) extends AnyVal
 
 object WriteScope {
   implicit val writeScopeEncoder: Encoder[WriteScope] =

--- a/src/test/scala/BadJsonDecodingSpec.scala
+++ b/src/test/scala/BadJsonDecodingSpec.scala
@@ -19,7 +19,7 @@ import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 import scala.util.Success
 
-case class SomeBadEvent(firstName: String, lastName: Int, uuid: UUID)
+final case class SomeBadEvent(firstName: String, lastName: Int, uuid: UUID)
 
 object SomeBadEvent {
   implicit val someBadEventEncoder: Encoder[SomeBadEvent] =

--- a/src/test/scala/OAuthFailedSpec.scala
+++ b/src/test/scala/OAuthFailedSpec.scala
@@ -35,7 +35,6 @@ class OAuthFailedSpec(implicit ec: ExecutionEnv) extends Specification with Futu
     Call to publishEvents should fail with invalid token        $oAuthPublishEvents
   """
 
-
   def oAuthCallSubscriptions = (name: String) => {
     implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)


### PR DESCRIPTION
This PR makes the `case class`'s `final`. The only exception here is the `case class` which represent the clients (these honestly shouldn't be `case class` but we will solve this problem later)