### PR TITLE
Upgrade to circe010x

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ a year, including handling events from Zalando's main website search.
 
 ### Installation
 
-Kanadi is currently deployed to OSS Sonatype
+Kanadi is currently deployed to OSS Sonatype. For Circe 0.10.x use Kanadi 0.3.x
+
+```sbt
+libraryDependencies ++= Seq(
+    "org.zalando" %% "kanadi" % "0.3.0"
+)
+```
+
+Otherwise if you need a Kanadi built against Circe 0.9.x use Kanadi 0.2.x
 
 ```sbt
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 name := """kanadi"""
 
-val akkaHttpVersion        = "10.1.3"
+val akkaHttpVersion        = "10.1.5"
 val akkaStreamsJsonVersion = "0.2.0"
 val currentScalaVersion    = "2.11.12"
 val enumeratumCirceVersion = "1.5.12"
 val circeVersion           = "0.10.0"
-val akkaVersion            = "2.5.12"
+val akkaVersion            = "2.5.17"
 
 scalaVersion in ThisBuild := currentScalaVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 name := """kanadi"""
 
 val akkaHttpVersion        = "10.1.3"
-val akkaStreamsJsonVersion = "0.1.0"
+val akkaStreamsJsonVersion = "0.2.0"
 val currentScalaVersion    = "2.11.12"
 val enumeratumCirceVersion = "1.5.12"
-val circeVersion           = "0.9.3"
+val circeVersion           = "0.10.0"
 val akkaVersion            = "2.5.12"
 
 scalaVersion in ThisBuild := currentScalaVersion
@@ -62,13 +62,13 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"          %% "akka-slf4j"          % akkaVersion,
   "com.typesafe.akka"          %% "akka-stream"         % akkaVersion,
   "org.mdedetrich"             %% "censored-raw-header" % "0.2.0",
-  "org.mdedetrich"             %% "webmodels"           % "0.2.0",
+  "org.mdedetrich"             %% "webmodels"           % "0.3.0",
   "com.beachape"               %% "enumeratum-circe"    % enumeratumCirceVersion,
   "io.circe"                   %% "circe-java8"         % circeVersion,
   "io.circe"                   %% "circe-parser"        % circeVersion,
   "org.mdedetrich"             %% "akka-stream-circe"   % akkaStreamsJsonVersion,
   "org.mdedetrich"             %% "akka-http-circe"     % akkaStreamsJsonVersion,
-  "de.heikoseeberger"          %% "akka-http-circe"     % "1.21.0",
+  "de.heikoseeberger"          %% "akka-http-circe"     % "1.22.0",
   "com.iheart"                 %% "ficus"               % "1.4.3",
   "com.typesafe.scala-logging" %% "scala-logging"       % "3.8.0",
   "ch.qos.logback"             % "logback-classic"      % "1.1.7",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.2.5-SNAPSHOT"
+version := "0.3.0"


### PR DESCRIPTION
Hade to make a new branch because Github was down yesterday

This PR is for setting up a new branch which is needed due to a new release for Circe 0.10.x. We will release Kanadi 0.3.x with the newest version of Circe 0.10.x where as Kanadi 0.2.x is for Circe 0.9.x (we will have to backport fixes from the branches)