### PR TITLE
Remove variable shadowing

### DIFF
--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -540,14 +540,7 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
         consumerGroupCheck && idCheck
       }
 
-      head = collect.headOption
-
-      createIfEmpty <- {
-        head match {
-          case Some(subscription) => Future.successful(subscription)
-          case None               => create(subscription)
-        }
-      }
+      createIfEmpty <- collect.headOption.map(Future(_)).getOrElse(create(subscription))
 
     } yield createIfEmpty
   }


### PR DESCRIPTION
Fix variable shadowing issue and replace match expression with map/getOrElse.

Fixes #49