### PR TITLE
Code cleanup + Fix SpanCtx model

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Kanadi is currently deployed to OSS Sonatype. For Circe 0.10.x use Kanadi 0.3.x
 
 ```sbt
 libraryDependencies ++= Seq(
-    "org.zalando" %% "kanadi" % "0.3.0"
+    "org.zalando" %% "kanadi" % "0.3.1"
 )
 ```
 
@@ -54,7 +54,7 @@ Otherwise if you need a Kanadi built against Circe 0.9.x use Kanadi 0.2.x
 
 ```sbt
 libraryDependencies ++= Seq(
-    "org.zalando" %% "kanadi" % "0.2.4"
+    "org.zalando" %% "kanadi" % "0.2.5"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,17 +20,44 @@ testForkedParallel in Test := true
 updateOptions := updateOptions.value.withGigahorse(false)
 
 scalacOptions ++= Seq(
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
   "-encoding",
-  "UTF-8",
-  "-deprecation", // warning and location for usages of deprecated APIs
-  "-feature", // warning and location for usages of features that should be imported explicitly
-  "-unchecked", // additional warnings where generated code depends on assumptions
-  "-Xlint", // recommended additional warnings
-  "-Xcheckinit", // runtime error when a val is not initialized due to trait hierarchies (instead of NPE somewhere else)
-  "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver
-  "-Ywarn-value-discard", // Warn when non-Unit expression results are unused
-  "-Ywarn-inaccessible",
-  "-Ywarn-dead-code"
+  "utf-8", // Specify character encoding used by source files.
+  "-explaintypes", // Explain type errors in more detail.
+  "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+  "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+  "-language:experimental.macros", // Allow macro definition (besides implementation and application)
+  "-language:higherKinds", // Allow higher-kinded types
+  "-language:implicitConversions", // Allow definition of implicit functions called views
+  "-unchecked",  // Enable additional warnings where generated code depends on assumptions.
+  "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+  //  "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+  "-Xfuture", // Turn on future language features.
+  "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+  "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+  "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+  "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+  "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+  "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+  "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+  "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
+  "-Xlint:option-implicit", // Option.apply used implicit view.
+  "-Xlint:package-object-classes", // Class or object defined in package object.
+  "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+  "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+  "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+  "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+  "-Xlint:unsound-match",         // Pattern match may not be typesafe.
+  //"-Yno-adapted-args", // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+  "-Ypartial-unification", // Enable partial unification in type constructor inference
+  "-Ywarn-dead-code", // Warn when dead code is identified.
+  "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+  "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
+  "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Ywarn-nullary-unit", // Warn when nullary methods return Unit.
+  "-Ywarn-numeric-widen", // Warn when numerics are widened.
+  "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
 )
 
 val flagsFor11 = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/src/main/scala/org/zalando/kanadi/api/Events.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Events.scala
@@ -286,9 +286,9 @@ case class Events(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvider]
     val finalEvents = if (fillMetadata) {
       events.map {
         case e: Event.Business[_] =>
-          e.copy(metadata = e.metadata.copy(eventType = Option(e.metadata.eventType.getOrElse(name))))
+          e.copy(metadata = e.metadata.copy(eventType = Some(e.metadata.eventType.getOrElse(name))))
         case e: Event.DataChange[_] =>
-          e.copy(metadata = e.metadata.copy(eventType = Option(e.metadata.eventType.getOrElse(name))))
+          e.copy(metadata = e.metadata.copy(eventType = Some(e.metadata.eventType.getOrElse(name))))
         case e: Event.Undefined[_] => e
       }
     } else events

--- a/src/main/scala/org/zalando/kanadi/models/SpanCtx.scala
+++ b/src/main/scala/org/zalando/kanadi/models/SpanCtx.scala
@@ -3,11 +3,11 @@ package org.zalando.kanadi.models
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
-final case class SpanCtx(ctx: String) extends AnyVal
+final case class SpanCtx(ctx: Map[String, String]) extends AnyVal
 
 object SpanCtx {
-  implicit val eventIdEncoder: Encoder[SpanCtx] =
+  implicit val spanCtxEncoder: Encoder[SpanCtx] =
     Encoder.instance[SpanCtx](_.ctx.asJson)
-  implicit val eventIdDecoder: Decoder[SpanCtx] =
-    Decoder[String].map(SpanCtx.apply)
+  implicit val spanCtxDecoder: Decoder[SpanCtx] =
+    Decoder[Map[String, String]].map(SpanCtx.apply)
 }

--- a/src/test/scala/AuthorizationSpec.scala
+++ b/src/test/scala/AuthorizationSpec.scala
@@ -91,8 +91,7 @@ class AuthorizationSpec(implicit ec: ExecutionEnv) extends Specification with Fu
       case _ =>
     }
 
-    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo(
-      (OwningApplication, Option(List(eventTypeName))))
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
       .await(0, timeout = 5 seconds)
   }
 

--- a/src/test/scala/BadJsonDecodingSpec.scala
+++ b/src/test/scala/BadJsonDecodingSpec.scala
@@ -93,8 +93,8 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
       Subscription(
         None,
         OwningApplication,
-        Option(List(eventTypeName)),
-        Option(consumerGroup)
+        Some(List(eventTypeName)),
+        Some(consumerGroup)
       ))
 
     future.onComplete {
@@ -104,8 +104,7 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
       case _ =>
     }
 
-    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo(
-      (OwningApplication, Option(List(eventTypeName))))
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
       .await(0, timeout = 3 seconds)
   }
 
@@ -162,7 +161,7 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
     val uUIDOne = java.util.UUID.randomUUID()
     val uUIDTwo = java.util.UUID.randomUUID()
 
-    events = Option(
+    events = Some(
       List(
         SomeEvent("Robert", "Terwilliger", uUIDOne),
         SomeEvent("Die", "Bart, Die", uUIDTwo)

--- a/src/test/scala/BasicSourceSpec.scala
+++ b/src/test/scala/BasicSourceSpec.scala
@@ -11,12 +11,12 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.specification.core.SpecStructure
 import org.zalando.kanadi.Config
-import org.zalando.kanadi.api.Subscriptions.{ConnectionClosedCallback, defaultEventStreamSupervisionDecider}
+import org.zalando.kanadi.api.Subscriptions.defaultEventStreamSupervisionDecider
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models._
 
 import scala.concurrent.duration._
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.Promise
 import scala.util.Success
 
 class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
@@ -72,8 +72,8 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
       Subscription(
         None,
         OwningApplication,
-        Option(List(eventTypeName)),
-        Option(consumerGroup)
+        Some(List(eventTypeName)),
+        Some(consumerGroup)
       ))
 
     future.onComplete {
@@ -83,8 +83,7 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
       case _ =>
     }
 
-    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo(
-      (OwningApplication, Option(List(eventTypeName))))
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
       .await(0, timeout = 5 seconds)
   }
 
@@ -130,7 +129,7 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
     val uUIDOne = java.util.UUID.randomUUID()
     val uUIDTwo = java.util.UUID.randomUUID()
 
-    events = Option(
+    events = Some(
       List(
         SomeEvent("Robert", "Terwilliger", uUIDOne),
         SomeEvent("Die", "Bart, Die", uUIDTwo)

--- a/src/test/scala/BasicSpec.scala
+++ b/src/test/scala/BasicSpec.scala
@@ -5,7 +5,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
-import io.circe.{Decoder, Encoder}
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
@@ -20,7 +19,7 @@ import org.zalando.kanadi.api.Subscriptions.{
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models._
 
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 import scala.util.Success
 
@@ -79,8 +78,8 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
       Subscription(
         None,
         OwningApplication,
-        Option(List(eventTypeName)),
-        Option(consumerGroup)
+        Some(List(eventTypeName)),
+        Some(consumerGroup)
       ))
 
     future.onComplete {
@@ -90,8 +89,7 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
       case _ =>
     }
 
-    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo(
-      (OwningApplication, Option(List(eventTypeName))))
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
       .await(0, timeout = 5 seconds)
   }
 
@@ -101,7 +99,7 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
     val uUIDOne = java.util.UUID.randomUUID()
     val uUIDTwo = java.util.UUID.randomUUID()
 
-    events = Option(
+    events = Some(
       List(
         SomeEvent("Robert", "Terwilliger", uUIDOne),
         SomeEvent("Die", "Bart, Die", uUIDTwo)

--- a/src/test/scala/CommitCursorBadResponseSpec.scala
+++ b/src/test/scala/CommitCursorBadResponseSpec.scala
@@ -64,8 +64,8 @@ class CommitCursorBadResponseSpec(implicit ec: ExecutionEnv) extends Specificati
       Subscription(
         None,
         OwningApplication,
-        Option(List(eventTypeName)),
-        Option(consumerGroup)
+        Some(List(eventTypeName)),
+        Some(consumerGroup)
       ))
 
     future.onComplete {
@@ -75,8 +75,7 @@ class CommitCursorBadResponseSpec(implicit ec: ExecutionEnv) extends Specificati
       case _ =>
     }
 
-    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo(
-      (OwningApplication, Option(List(eventTypeName))))
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
       .await(0, timeout = 5 seconds)
   }
 

--- a/src/test/scala/OAuthFailedSpec.scala
+++ b/src/test/scala/OAuthFailedSpec.scala
@@ -22,7 +22,7 @@ class OAuthFailedSpec(implicit ec: ExecutionEnv) extends Specification with Futu
   implicit val system       = ActorSystem()
   implicit val http         = Http()
   implicit val materializer = ActorMaterializer()
-  val failingOauth2TokenProvider = Option(
+  val failingOauth2TokenProvider = Some(
     OAuth2TokenProvider(() => Future.successful(OAuth2Token("Failing token")))
   )
 

--- a/src/test/scala/TokenProvider.scala
+++ b/src/test/scala/TokenProvider.scala
@@ -7,5 +7,5 @@ object TokenProvider {
     throw new IllegalArgumentException("Expected token")
   )
 
-  val environmentTokenProvider = Option(OAuth2TokenProvider(() => Future.successful(OAuth2Token(token))))
+  val environmentTokenProvider = Some(OAuth2TokenProvider(() => Future.successful(OAuth2Token(token))))
 }

--- a/src/test/scala/org/zalando/kanadi/URIDecodingSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/URIDecodingSpec.scala
@@ -3,10 +3,9 @@ package org.zalando.kanadi
 import java.net.URI
 import io.circe.syntax._
 import org.specs2.Specification
-import org.specs2.concurrent.ExecutionEnv
 
-class URIDecodingSpec(implicit ec: ExecutionEnv) extends Specification {
-  override def is = sequential ^ s2"""
+class URIDecodingSpec extends Specification {
+  override def is = s2"""
       Encode and decode an absolute URI $absoluteURI
       Encode and decode a relative URI $relativeURI
       """


### PR DESCRIPTION
This PR does the following things

1. Replaces `Option` constructors with `Some` (`Some.apply` is much faster than `Option.apply`, there is no reason to use `Option` unless you are interopting with code that uses `null`.
2. Adds a lot more flags to help identify issues in code. Unfortunately we can't turn warnings into errors because there are stub imports that are used in Cats. Doing this has removed a lot of redundant imports.
3. Fixes the `span_ctx` field to be the proper type (i.e. `Map[String, String]`). Tests have been added to verify this (we used actual examples from Nakadi to verify this)
4. Fixes the versions in README.md