### PR TITLE
Added check to avoid unnecessary or even invalid cursor commit requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ project/plugins/project/
 .history
 .cache
 .lib/
-
+.idea/

--- a/README.md
+++ b/README.md
@@ -589,6 +589,12 @@ directly may be to use the source stream directly (detailed [below](#using-the-s
 akka-streams are fully 
 [backpressured](https://doc.akka.io/docs/akka/2.5.3/scala/stream/stream-flows-and-basics.html#back-pressure-explained).
 
+Cursors within a `eventsStreamManaged` are committed automatically for batches which contain the `events` property
+(`eventCallbackData.subscriptionEvent.events`). Whenever the end of the stream is reached and no new events are received,
+Nakadi will keep the connection open by sending “keep-alive” batches. These batches don’t contain the `events` property
+and therefore are not committed. If there is for some reason the need to override this default behavior, `commitCursors`
+takes the boolean flag `eventBatch` as fourth parameter. If it is set to `true` the cursors will be committed.
+
 #### Using the source stream directly
 
 There is also a `Subscriptions.eventsStreamedSource` method which exposes the Nakadi stream as an akka-stream `Source`,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.8

--- a/src/main/scala/org/zalando/kanadi/api/SubscriptionsInterface.scala
+++ b/src/main/scala/org/zalando/kanadi/api/SubscriptionsInterface.scala
@@ -41,7 +41,10 @@ trait SubscriptionsInterface {
       executionContext: ExecutionContext
   ): Future[Option[SubscriptionCursor]]
 
-  def commitCursors(subscriptionId: SubscriptionId, subscriptionCursor: SubscriptionCursor, streamId: StreamId)(
+  def commitCursors(subscriptionId: SubscriptionId,
+                    subscriptionCursor: SubscriptionCursor,
+                    streamId: StreamId,
+                    eventBatch: Boolean)(
       implicit flowId: FlowId = randomFlowId(),
       executionContext: ExecutionContext
   ): Future[Option[CommitCursorResponse]]

--- a/src/test/scala/CommitCursorOmittedSpec.scala
+++ b/src/test/scala/CommitCursorOmittedSpec.scala
@@ -1,0 +1,111 @@
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import com.typesafe.config.ConfigFactory
+import io.circe.JsonObject
+import org.mdedetrich.webmodels.FlowId
+import org.specs2.Specification
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers
+import org.specs2.specification.core.SpecStructure
+import org.zalando.kanadi.Config
+import org.zalando.kanadi.api._
+import org.zalando.kanadi.models.{EventTypeName, SubscriptionId}
+
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util._
+
+class CommitCursorOmittedSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
+  override def is: SpecStructure = sequential ^ s2"""
+    Create Event Type          $createEventType
+    Create Subscription events $createSubscription
+    Stream subscription        $streamSubscriptionId
+  """
+
+  val config = ConfigFactory.load()
+
+  implicit val system       = ActorSystem()
+  implicit val http         = Http()
+  implicit val materializer = ActorMaterializer()
+
+  val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
+
+  eventTypeName.pp
+
+  val OwningApplication = "KANADI"
+
+  val consumerGroup = UUID.randomUUID().toString
+
+  s"Consumer Group: $consumerGroup".pp
+
+  val subscriptionsClient =
+    Subscriptions(nakadiUri, None)
+  val eventsClient = Events(nakadiUri, None)
+  val eventsTypesClient =
+    EventTypes(nakadiUri, None)
+
+  val currentSubscriptionId: Promise[SubscriptionId]                             = Promise()
+  val successfullyParsedBadCommitResponse: Promise[Option[CommitCursorResponse]] = Promise()
+
+  def createEventType = (name: String) => {
+    val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
+
+    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+  }
+
+  def createSubscription = (name: String) => {
+    implicit val flowId: FlowId = Utils.randomFlowId()
+    flowId.pp(name)
+    val future = subscriptionsClient.createIfDoesntExist(
+      Subscription(
+        None,
+        OwningApplication,
+        Some(List(eventTypeName)),
+        Some(consumerGroup)
+      ))
+
+    future.onComplete {
+      case Success(subscription) =>
+        subscription.id.pp
+        currentSubscriptionId.complete(Success(subscription.id.get))
+      case _ =>
+    }
+
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
+      .await(0, timeout = 5 seconds)
+  }
+
+  def streamSubscriptionId = (name: String) => {
+    implicit val flowId: FlowId = Utils.randomFlowId()
+    flowId.pp(name)
+
+    val future = for {
+      subscriptionId <- currentSubscriptionId.future
+      _ = subscriptionsClient.eventsStreamedSource[JsonObject](subscriptionId).map { nakadiSource =>
+        nakadiSource.source
+          .map { subscriptionEvent =>
+            subscriptionsClient
+              .commitCursors(subscriptionId,
+                             SubscriptionCursor(List(subscriptionEvent.cursor)),
+                             nakadiSource.streamId,
+                             eventBatch = false)
+              .onComplete {
+                case Success(response) =>
+                  successfullyParsedBadCommitResponse.complete(Success(response))
+                case Failure(e) =>
+                  successfullyParsedBadCommitResponse.complete(Failure(e))
+              }
+
+          }
+          .runWith(Sink.foreach(_ => ()))
+      }
+      result <- successfullyParsedBadCommitResponse.future
+    } yield result
+
+    future must beNone.await(0, timeout = 2 minutes)
+  }
+}


### PR DESCRIPTION
Solves #87 

This might not be the most idiomatic way of solving this issue, but it would avoid unnecessary or even invalid cursor commit requests right away. If the “simulated” request is not an option for you the `eventBatch` parameter can also be used to wrap the `logger.warn` call in line 779.

Additionally I had to increase SBT version to 1.2.8 in order to be able to use it with OpenJDK 1.8.0_202.