### PR TITLE
Skip the OAuth fail spec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,24 @@ publishTo := {
     Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
+def emptyStringToNone(string: String): Option[String] =
+  if (string.trim.isEmpty)
+    None
+  else
+    Some(string)
+
+javaOptions ++= sys.props
+  .get("TOKEN")
+  .flatMap(emptyStringToNone)
+  .map { token =>
+    s"-DTOKEN=$token"
+  }
+  .toList
+
+envVars ++= Map("TOKEN" -> sys.env.get("TOKEN").flatMap(emptyStringToNone)).collect {
+  case (k, Some(v)) => (k, v)
+}
+
 publishArtifact in Test := false
 
 pomIncludeRepository := (_ => false)

--- a/src/test/scala/OAuthFailedSpec.scala
+++ b/src/test/scala/OAuthFailedSpec.scala
@@ -6,6 +6,7 @@ import io.circe.Json
 import org.mdedetrich.webmodels.{FlowId, OAuth2Token, OAuth2TokenProvider}
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Skipped
 import org.specs2.matcher.FutureMatchers
 import org.specs2.specification.core.SpecStructure
 import org.zalando.kanadi.Config
@@ -35,12 +36,7 @@ class OAuthFailedSpec(implicit ec: ExecutionEnv) extends Specification with Futu
     Call to publishEvents should fail with invalid token        $oAuthPublishEvents
   """
 
-  def oAuthCallSubscriptions = (name: String) => {
-    implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
-    subscriptionsClient.list() must throwA[GeneralError]
-      .await(0, timeout = 3 seconds)
-  }
+  def oAuthCallSubscriptions = Skipped("No way for current Nakadi docker image to detect 'wrong' tokens")
 
   def oAuthPublishEvents = (name: String) => {
     implicit val flowId: FlowId = Utils.randomFlowId()

--- a/src/test/scala/TokenProvider.scala
+++ b/src/test/scala/TokenProvider.scala
@@ -3,9 +3,21 @@ import org.mdedetrich.webmodels.{OAuth2Token, OAuth2TokenProvider}
 import scala.concurrent.Future
 
 object TokenProvider {
-  private val token = (sys.props.get("TOKEN") orElse sys.env.get("TOKEN")).getOrElse(
-    throw new IllegalArgumentException("Expected token")
-  )
+  private def emptyStringToNone(string: String): Option[String] =
+    if (string.trim.isEmpty)
+      None
+    else
+      Some(string)
 
-  val environmentTokenProvider = Some(OAuth2TokenProvider(() => Future.successful(OAuth2Token(token))))
+  def getDataFromEnv(id: String): String =
+    sys.props
+      .get(id)
+      .flatMap(emptyStringToNone)
+      .orElse(sys.env.get(id).flatMap(emptyStringToNone))
+      .getOrElse(throw new IllegalArgumentException(s"Unable to get $id from the environment"))
+
+
+  private val token = getDataFromEnv("TOKEN")
+
+  lazy val environmentTokenProvider = Some(OAuth2TokenProvider(() => Future.successful(OAuth2Token(token))))
 }


### PR DESCRIPTION
This PR skips the OAuth failed spec, this is due to the fact that the current nakadi docker-compose that we run our integration tests against will accept any token as a valid one so its not really possible to test it this way.

In the future we should try and mock such a response.

The PR also improves the token handling for passing the token via environment variables should we need this functionality in the future