### PR TITLE
Add documentation for OpenTracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ project/plugins/project/
 .history
 .cache
 .lib/
-.idea/


### PR DESCRIPTION
This PR adds some documentation about `OpenTracing` to Scala, as well as documenting some other things.

Also removes the `.idea` from `.gitignore` (people should be using a global `.gitignore`)